### PR TITLE
Hide usage on runtime errors, show on syntax errors

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -71,3 +71,227 @@ func TestLogsCommand_MissingFlags(t *testing.T) {
 		t.Errorf("Expected error for missing required flags, got: %v", err)
 	}
 }
+
+// Test that syntax errors show usage text
+func TestResourcesCommand_MissingFlags_ShowsUsage(t *testing.T) {
+	output, err := executeCommand(rootCmd, "resources")
+	if err == nil {
+		t.Errorf("Expected error for missing required flags")
+	}
+
+	if !strings.Contains(output, "Usage:") {
+		t.Errorf("Expected usage text to be shown for syntax errors, got: %s", output)
+	}
+
+	if !strings.Contains(output, "kgrep resources [flags]") {
+		t.Errorf("Expected command usage line to be shown, got: %s", output)
+	}
+
+	if !strings.Contains(output, "Flags:") {
+		t.Errorf("Expected flags section to be shown, got: %s", output)
+	}
+}
+
+func TestPodsCommand_MissingFlags_ShowsUsage(t *testing.T) {
+	output, err := executeCommand(rootCmd, "pods")
+	if err == nil {
+		t.Errorf("Expected error for missing required flags")
+	}
+
+	if !strings.Contains(output, "Usage:") {
+		t.Errorf("Expected usage text to be shown for syntax errors, got: %s", output)
+	}
+
+	if !strings.Contains(output, "kgrep pods [flags]") {
+		t.Errorf("Expected command usage line to be shown, got: %s", output)
+	}
+}
+
+func TestConfigMapsCommand_MissingFlags_ShowsUsage(t *testing.T) {
+	output, err := executeCommand(rootCmd, "configmaps")
+	if err == nil {
+		t.Errorf("Expected error for missing required flags")
+	}
+
+	if !strings.Contains(output, "Usage:") {
+		t.Errorf("Expected usage text to be shown for syntax errors, got: %s", output)
+	}
+
+	if !strings.Contains(output, "kgrep configmaps [flags]") {
+		t.Errorf("Expected command usage line to be shown, got: %s", output)
+	}
+}
+
+func TestSecretsCommand_MissingFlags_ShowsUsage(t *testing.T) {
+	output, err := executeCommand(rootCmd, "secrets")
+	if err == nil {
+		t.Errorf("Expected error for missing required flags")
+	}
+
+	if !strings.Contains(output, "Usage:") {
+		t.Errorf("Expected usage text to be shown for syntax errors, got: %s", output)
+	}
+
+	if !strings.Contains(output, "kgrep secrets [flags]") {
+		t.Errorf("Expected command usage line to be shown, got: %s", output)
+	}
+}
+
+func TestServiceAccountsCommand_MissingFlags_ShowsUsage(t *testing.T) {
+	output, err := executeCommand(rootCmd, "serviceaccounts")
+	if err == nil {
+		t.Errorf("Expected error for missing required flags")
+	}
+
+	if !strings.Contains(output, "Usage:") {
+		t.Errorf("Expected usage text to be shown for syntax errors, got: %s", output)
+	}
+
+	if !strings.Contains(output, "kgrep serviceaccounts [flags]") {
+		t.Errorf("Expected command usage line to be shown, got: %s", output)
+	}
+}
+
+func TestLogsCommand_MissingFlags_ShowsUsage(t *testing.T) {
+	output, err := executeCommand(rootCmd, "logs")
+	if err == nil {
+		t.Errorf("Expected error for missing required flags")
+	}
+
+	if !strings.Contains(output, "Usage:") {
+		t.Errorf("Expected usage text to be shown for syntax errors, got: %s", output)
+	}
+
+	if !strings.Contains(output, "kgrep logs [flags]") {
+		t.Errorf("Expected command usage line to be shown, got: %s", output)
+	}
+}
+
+// Test that runtime errors (correct syntax) don't show usage text
+func TestResourcesCommand_RuntimeError_NoUsage(t *testing.T) {
+	// This test simulates a runtime error with correct syntax
+	// We can't easily test actual Kubernetes connectivity errors in unit tests,
+	// but we can test that SilenceUsage works properly by using a command
+	// that will fail during execution rather than during flag validation
+
+	// Using a non-existent resource type will cause a runtime error
+	output, err := executeCommand(rootCmd, "resources", "--kind", "NonExistentResource", "--pattern", "test")
+	if err == nil {
+		t.Errorf("Expected error for non-existent resource")
+	}
+
+	// The error should be present but no usage should be shown
+	if !strings.Contains(output, "Error:") {
+		t.Errorf("Expected error message to be shown, got: %s", output)
+	}
+
+	if strings.Contains(output, "Usage:") {
+		t.Errorf("Expected no usage text for runtime errors, got: %s", output)
+	}
+
+	if strings.Contains(output, "kgrep resources [flags]") {
+		t.Errorf("Expected no command usage line for runtime errors, got: %s", output)
+	}
+
+	if strings.Contains(output, "Flags:") {
+		t.Errorf("Expected no flags section for runtime errors, got: %s", output)
+	}
+}
+
+func TestPodsCommand_RuntimeError_NoUsage(t *testing.T) {
+	// Test that pods command with correct syntax but runtime error doesn't show usage
+	// Since providing a non-existent namespace might not always cause an error,
+	// we'll test that SilenceUsage is properly set by checking the behavior
+	// when there's no actual error (successful execution should not show usage either)
+	output, err := executeCommand(rootCmd, "pods", "--pattern", "test", "--namespace", "non-existent-namespace")
+
+	// Whether there's an error or not, usage should not be shown for correct syntax
+	if strings.Contains(output, "Usage:") {
+		t.Errorf("Expected no usage text for commands with correct syntax, got: %s", output)
+	}
+
+	if strings.Contains(output, "kgrep pods [flags]") {
+		t.Errorf("Expected no command usage line for commands with correct syntax, got: %s", output)
+	}
+
+	// If there is an error, it should be a runtime error, not a syntax error
+	if err != nil && strings.Contains(err.Error(), "required flag") {
+		t.Errorf("Unexpected syntax error for command with correct syntax: %v", err)
+	}
+}
+
+func TestConfigMapsCommand_RuntimeError_NoUsage(t *testing.T) {
+	// Test that configmaps command with correct syntax doesn't show usage
+	output, err := executeCommand(rootCmd, "configmaps", "--pattern", "test", "--namespace", "non-existent-namespace")
+
+	// Whether there's an error or not, usage should not be shown for correct syntax
+	if strings.Contains(output, "Usage:") {
+		t.Errorf("Expected no usage text for commands with correct syntax, got: %s", output)
+	}
+
+	if strings.Contains(output, "kgrep configmaps [flags]") {
+		t.Errorf("Expected no command usage line for commands with correct syntax, got: %s", output)
+	}
+
+	// If there is an error, it should be a runtime error, not a syntax error
+	if err != nil && strings.Contains(err.Error(), "required flag") {
+		t.Errorf("Unexpected syntax error for command with correct syntax: %v", err)
+	}
+}
+
+func TestSecretsCommand_RuntimeError_NoUsage(t *testing.T) {
+	// Test that secrets command with correct syntax doesn't show usage
+	output, err := executeCommand(rootCmd, "secrets", "--pattern", "test", "--namespace", "non-existent-namespace")
+
+	// Whether there's an error or not, usage should not be shown for correct syntax
+	if strings.Contains(output, "Usage:") {
+		t.Errorf("Expected no usage text for commands with correct syntax, got: %s", output)
+	}
+
+	if strings.Contains(output, "kgrep secrets [flags]") {
+		t.Errorf("Expected no command usage line for commands with correct syntax, got: %s", output)
+	}
+
+	// If there is an error, it should be a runtime error, not a syntax error
+	if err != nil && strings.Contains(err.Error(), "required flag") {
+		t.Errorf("Unexpected syntax error for command with correct syntax: %v", err)
+	}
+}
+
+func TestServiceAccountsCommand_RuntimeError_NoUsage(t *testing.T) {
+	// Test that serviceaccounts command with correct syntax doesn't show usage
+	output, err := executeCommand(rootCmd, "serviceaccounts", "--pattern", "test", "--namespace", "non-existent-namespace")
+
+	// Whether there's an error or not, usage should not be shown for correct syntax
+	if strings.Contains(output, "Usage:") {
+		t.Errorf("Expected no usage text for commands with correct syntax, got: %s", output)
+	}
+
+	if strings.Contains(output, "kgrep serviceaccounts [flags]") {
+		t.Errorf("Expected no command usage line for commands with correct syntax, got: %s", output)
+	}
+
+	// If there is an error, it should be a runtime error, not a syntax error
+	if err != nil && strings.Contains(err.Error(), "required flag") {
+		t.Errorf("Unexpected syntax error for command with correct syntax: %v", err)
+	}
+}
+
+func TestLogsCommand_RuntimeError_NoUsage(t *testing.T) {
+	// Test that logs command with correct syntax doesn't show usage
+	output, err := executeCommand(rootCmd, "logs", "--pattern", "test", "--namespace", "non-existent-namespace")
+
+	// Whether there's an error or not, usage should not be shown for correct syntax
+	if strings.Contains(output, "Usage:") {
+		t.Errorf("Expected no usage text for commands with correct syntax, got: %s", output)
+	}
+
+	if strings.Contains(output, "kgrep logs [flags]") {
+		t.Errorf("Expected no command usage line for commands with correct syntax, got: %s", output)
+	}
+
+	// If there is an error, it should be a runtime error, not a syntax error
+	if err != nil && strings.Contains(err.Error(), "required flag") {
+		t.Errorf("Unexpected syntax error for command with correct syntax: %v", err)
+	}
+}

--- a/cmd/configmaps.go
+++ b/cmd/configmaps.go
@@ -17,6 +17,8 @@ var configmapsCmd = &cobra.Command{
 	Short: "Search ConfigMaps in Kubernetes",
 	Long:  `Search the content of ConfigMaps for specific patterns within designated namespaces.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// For runtime errors, we don't want to show usage
+		cmd.SilenceUsage = true
 		if configmapsPattern == "" {
 			return fmt.Errorf("pattern is required")
 		}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -21,6 +21,8 @@ var logsCmd = &cobra.Command{
 	Short: "Search logs in Kubernetes",
 	Long:  `Search logs from a group of pods or entire namespaces, filtering by custom patterns.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// For runtime errors, we don't want to show usage
+		cmd.SilenceUsage = true
 		color.NoColor = false // Force color output
 
 		if logsPattern == "" {

--- a/cmd/pods.go
+++ b/cmd/pods.go
@@ -17,6 +17,8 @@ var podsCmd = &cobra.Command{
 	Short: "Search Pods in Kubernetes",
 	Long:  `Search the content of Pods for specific patterns within designated namespaces.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// For runtime errors, we don't want to show usage
+		cmd.SilenceUsage = true
 		if podsPattern == "" {
 			return fmt.Errorf("pattern is required")
 		}

--- a/cmd/resources.go
+++ b/cmd/resources.go
@@ -19,13 +19,8 @@ var resourcesCmd = &cobra.Command{
 	Short: "Search Generic Resources in Kubernetes",
 	Long:  `Search the content of any Kubernetes resource for specific patterns within designated namespaces.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if resourcesPattern == "" {
-			return fmt.Errorf("pattern is required")
-		}
-
-		if resourcesKind == "" {
-			return fmt.Errorf("kind is required")
-		}
+		// For runtime errors, we don't want to show usage
+		cmd.SilenceUsage = true
 
 		var resourceSearcher *resource.Searcher
 		var err error

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -18,6 +18,8 @@ var secretsCmd = &cobra.Command{
 	Short: "Search Secrets in Kubernetes",
 	Long:  `Search the content of Secrets for specific patterns within designated namespaces.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// For runtime errors, we don't want to show usage
+		cmd.SilenceUsage = true
 		color.NoColor = false // Force color output
 
 		if secretsPattern == "" {

--- a/cmd/serviceaccounts.go
+++ b/cmd/serviceaccounts.go
@@ -17,6 +17,8 @@ var serviceaccountsCmd = &cobra.Command{
 	Short: "Search ServiceAccounts in Kubernetes",
 	Long:  `Search the content of ServiceAccounts for specific patterns within designated namespaces.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// For runtime errors, we don't want to show usage
+		cmd.SilenceUsage = true
 		if serviceaccountsPattern == "" {
 			return fmt.Errorf("pattern is required")
 		}

--- a/main.go
+++ b/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"os"
+
 	"github.com/hbelmiro/kgrep/cmd"
-	"log"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		log.Fatal(err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Commands with correct syntax but runtime failures (e.g. Kubernetes API errors) no longer show confusing usage text. Syntax errors like missing required flags still show helpful usage information.

Also removes duplicate error logging that caused double error messages.

Fixes #149