### PR TITLE
Added support for cluster-scoped resources like namespaces

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -698,3 +698,126 @@ func TestIntegration_CustomResourceSearchContent(t *testing.T) {
 		})
 	}
 }
+
+func TestIntegration_ClusterScopedResourceSearch(t *testing.T) {
+	clientset := setupKubernetesClient(t)
+	namespaceName := getTestNamespace(t)
+
+	createTestNamespace(t, clientset, namespaceName)
+	defer cleanupTestNamespace(t, clientset, namespaceName)
+
+	output, err := runKgrepCommand(t, "resources", "-k", "namespace", "-p", namespaceName)
+	assert.NoError(t, err)
+	assert.Contains(t, output, namespaceName, "Should find the test namespace")
+
+	output, err = runKgrepCommand(t, "resources", "-k", "namespaces", "-p", namespaceName)
+	assert.NoError(t, err)
+	assert.Contains(t, output, namespaceName, "Should find the test namespace using plural form")
+}
+
+func TestIntegration_NamespacedResourceIsolation(t *testing.T) {
+	clientset := setupKubernetesClient(t)
+	namespace1 := getTestNamespace(t)
+	namespace2 := getTestNamespace(t)
+
+	createTestNamespace(t, clientset, namespace1)
+	createTestNamespace(t, clientset, namespace2)
+	defer func() {
+		cleanupTestNamespace(t, clientset, namespace1)
+		cleanupTestNamespace(t, clientset, namespace2)
+	}()
+
+	configMap1 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: namespace1,
+		},
+		Data: map[string]string{
+			"config": "unique-content-namespace1",
+		},
+	}
+
+	configMap2 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: namespace2,
+		},
+		Data: map[string]string{
+			"config": "unique-content-namespace2",
+		},
+	}
+
+	_, err := clientset.CoreV1().ConfigMaps(namespace1).Create(context.Background(), configMap1, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = clientset.CoreV1().ConfigMaps(namespace2).Create(context.Background(), configMap2, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	output, err := runKgrepCommand(t, "resources", "-k", "configmap", "-n", namespace1, "-p", "unique-content-namespace1")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "unique-content-namespace1", "Should find content from namespace1")
+
+	output, err = runKgrepCommand(t, "resources", "-k", "configmap", "-n", namespace1, "-p", "unique-content-namespace2")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "No occurrences", "Should not find content from namespace2 when searching in namespace1")
+
+	output, err = runKgrepCommand(t, "resources", "-k", "configmap", "-n", namespace2, "-p", "unique-content-namespace2")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "unique-content-namespace2", "Should find content from namespace2")
+
+	output, err = runKgrepCommand(t, "resources", "-k", "configmap", "-n", namespace2, "-p", "unique-content-namespace1")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "No occurrences", "Should not find content from namespace1 when searching in namespace2")
+}
+
+func TestIntegration_NonExistentNamespaceIsolation(t *testing.T) {
+	clientset := setupKubernetesClient(t)
+	realNamespace := getTestNamespace(t)
+	nonExistentNamespace := "non-existent-namespace-12345"
+
+	createTestNamespace(t, clientset, realNamespace)
+	defer cleanupTestNamespace(t, clientset, realNamespace)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: realNamespace,
+		},
+		Data: map[string]string{
+			"config": "content-in-real-namespace",
+		},
+	}
+
+	_, err := clientset.CoreV1().ConfigMaps(realNamespace).Create(context.Background(), configMap, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	output, err := runKgrepCommand(t, "resources", "-k", "configmap", "-n", nonExistentNamespace, "-p", "content-in-real-namespace")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "No occurrences", "Should not find content from real namespace when searching in non-existent namespace")
+
+	output, err = runKgrepCommand(t, "resources", "-k", "configmap", "-n", realNamespace, "-p", "content-in-real-namespace")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "content-in-real-namespace", "Should find content when searching in correct namespace")
+}
+
+func TestIntegration_ClusterScopedVsNamespacedBehavior(t *testing.T) {
+	clientset := setupKubernetesClient(t)
+	testNamespace := getTestNamespace(t)
+
+	createTestNamespace(t, clientset, testNamespace)
+	defer cleanupTestNamespace(t, clientset, testNamespace)
+
+	output, err := runKgrepCommand(t, "resources", "-k", "namespace", "-n", testNamespace, "-p", "default")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "default", "Should find default namespace even when specifying a different namespace for cluster-scoped resources")
+
+	createTestPod(t, clientset, testNamespace)
+
+	output, err = runKgrepCommand(t, "resources", "-k", "pod", "-n", testNamespace, "-p", "test-pod")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "test-pod", "Should find pod in specified namespace")
+
+	output, err = runKgrepCommand(t, "resources", "-k", "pod", "-n", "default", "-p", "test-pod")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "No occurrences", "Should not find pod from test namespace when searching in default namespace")
+}


### PR DESCRIPTION
Fixes #148 - resources command can now find cluster-scoped resources like namespaces.

The issue was that cluster-scoped resources (like namespaces) were being searched 
within a specific namespace, which fails. Modified getGenericResourceNames and 
getGenericResourceYAML methods to fall back to cluster-wide search (empty namespace) 
when the namespaced search fails.

This approach:
- Enables namespace resources to work correctly  
- Preserves namespace isolation for namespaced resources
- Only falls back to cluster-wide search when appropriate (for cluster-scoped resources)

Added comprehensive test coverage:
- Integration tests for cluster-scoped vs namespaced resource behavior
- Unit tests for the fallback logic and routing behavior
- Tests to ensure namespace isolation is preserved

Changes:
- Modified internal/resource/resource_searcher.go to add fallback logic
- Added integration tests in test/integration/integration_test.go
- Added unit tests in internal/resource/resource_searcher_test.go