### PR TITLE
chore: group codeql-action dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
## Summary
- Add a Dependabot group for `codeql-action` in the `github-actions` ecosystem entry so that all `github/codeql-action/*` updates are bundled into a single PR.

## Test plan
- [ ] Verify the `dependabot.yaml` syntax is valid
- [ ] Confirm future codeql-action bumps arrive as a single grouped PR